### PR TITLE
Use cmdstan_path() for more robust CmdStan availability check

### DIFF
--- a/tests/testthat/test-weights.R
+++ b/tests/testthat/test-weights.R
@@ -1,10 +1,10 @@
 library("data.table")
 
 test_that("Generating CRPS weights works", {
-  cmdstan_available <- tryCatch(
-    !is.null(cmdstanr::cmdstan_version()),
-    error = function(e) FALSE
-  )
+  cmdstan_available <- tryCatch({
+    path <- cmdstanr::cmdstan_path()
+    dir.exists(path)
+  }, error = function(e) FALSE)
   skip_if_not(cmdstan_available, "CmdStan not available")
   splitdate <- as.Date("2020-03-28")
 


### PR DESCRIPTION
## Summary
- Uses `cmdstan_path()` instead of `cmdstan_version()` for checking CmdStan availability in tests
- Adds `dir.exists()` check to verify the path actually exists on disk

Addresses test failures on R-universe where CmdStan is not installed: https://github.com/r-universe/epiforecasts/actions/runs/21127453071/job/60751592301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced CmdStan availability verification in test suite for improved reliability during testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->